### PR TITLE
fix(deps-security): upgrade axios to 0.21.4 to fix CVE-2021-3749

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.1"
+        "axios": "^0.21.4"
       },
       "devDependencies": {
         "@types/jest": "^26.0.24",
@@ -1143,10 +1143,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5323,10 +5324,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "babel-jest": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "jest --config ./tests/jest.config.js"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.21.4"
   },
   "devDependencies": {
     "@types/jest": "^26.0.24",


### PR DESCRIPTION
rel:
* [CVE-2021-3749](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3749)
* [SNYK-JS-AXIOS-1579269](https://app.snyk.io/vuln/SNYK-JS-AXIOS-1579269)
