### PR TITLE
fix(errors): less verbose messages

### DIFF
--- a/errors.ts
+++ b/errors.ts
@@ -117,7 +117,7 @@ export class FgaApiValidationError extends FgaApiError {
     this.message = msg
       ? msg
       : (err.response?.data as any)?.message
-        ? `FGA API Validation Error: ${err.config?.method} ${endpointCategory} : Error ${(err.response?.data as any)?.message}`
+        ? `${err.config?.method} ${endpointCategory}: ${(err.response?.data as any)?.message}`
         : (err as Error).message;
   }
 }


### PR DESCRIPTION
Currently: `FgaApiValidationError: FGA API Validation Error: post write : Error Invalid input. Make sure you provide at least one write, or at least one delete`

With this PR: `FgaApiValidationError: post write: Invalid input. Make sure you provide at least one write, or at least one delete`